### PR TITLE
avoid updating browser history multiple time for one search click

### DIFF
--- a/search.html
+++ b/search.html
@@ -353,39 +353,28 @@
             find(searchTerm);
         }
         
-        function updateQParameter(value) 
+        function updateQParameter(currentUrl, value)
         {
-            let currentUrl = new URL(window.location.href);
-            
             if ((value == null) || (value == ''))
                 currentUrl.searchParams.delete('q');
             else
                 currentUrl.searchParams.set('q', value);
-    
-            // Update the browser URL without causing a page reload
-            history.pushState(null, null, currentUrl.toString());
         }
         
-        function updateCTParameters() 
+        function updateCTParameters(currentUrl)
         {
             const selectElement = document.getElementById('searchType');
             const searchType = selectElement.options[selectElement.selectedIndex].value;
         
-            let currentUrl = new URL(window.location.href);
             // 2 is the default search type (all words)
             if (searchType == 2)
                 currentUrl.searchParams.delete('t');
             else
                 currentUrl.searchParams.set('t', searchType);
-    
-            // Update the browser URL without causing a page reload
-            history.pushState(null, null, currentUrl.toString());
         }
                         
-        function updateDateParams(startMonth, startDay, startYear, endMonth, endDay, endYear)
+        function updateDateParams(currentUrl, startMonth, startDay, startYear, endMonth, endDay, endYear)
         {
-            let currentUrl = new URL(window.location.href);
-            
             if (startMonth == -1)
                 currentUrl.searchParams.delete('sm');
             else
@@ -415,15 +404,10 @@
                 currentUrl.searchParams.delete('ey');
             else
                 currentUrl.searchParams.set('ey', endYear);
-                
-            // Update the browser URL without causing a page reload
-            history.pushState(null, null, currentUrl.toString());
         }
         
-        function updateMiscOptions(maxResults, mostRecentFirst)
+        function updateMiscOptions(currentUrl, maxResults, mostRecentFirst)
         {
-            let currentUrl = new URL(window.location.href);
-            
             if (maxResults == DEFAULT_MAX_RESULTS)
                 currentUrl.searchParams.delete('x');
             else
@@ -433,22 +417,14 @@
                 currentUrl.searchParams.delete('mr');
             else
                 currentUrl.searchParams.set('mr', 0);
-            
-            // Update the browser URL without causing a page reload
-            history.pushState(null, null, currentUrl.toString());
         }
         
-        function updateSource(sourceStr)
+        function updateSource(currentUrl, sourceStr)
         {
-            let currentUrl = new URL(window.location.href);
-            
             if ((sourceStr == null) || (sourceStr == ""))
                 currentUrl.searchParams.delete('sl');
             else
                 currentUrl.searchParams.set('sl', sourceStr);
-            
-            // Update the browser URL without causing a page reload
-            history.pushState(null, null, currentUrl.toString());
         }
         
         function forceRepaint(element) {
@@ -515,12 +491,12 @@
             
             let mostRecentFirst = document.getElementById("mostRecentFirst").checked ? 1 : 0;
             let bruteForceSearch = false;
-            
-            updateQParameter(searchTerm);
-            updateCTParameters();
-            updateDateParams(startMonth, startDay, startYear, endMonth, endDay, endYear);
-            updateMiscOptions(maxResults, mostRecentFirst);
-                                                            
+            let currentUrl = new URL(window.location.href);
+            updateQParameter(currentUrl, searchTerm);
+            updateCTParameters(currentUrl);
+            updateDateParams(currentUrl, startMonth, startDay, startYear, endMonth, endDay, endYear);
+            updateMiscOptions(currentUrl, maxResults, mostRecentFirst);
+
             const selectElement = document.getElementById('searchType');
             const searchType = selectElement.options[selectElement.selectedIndex].value;
             
@@ -545,7 +521,9 @@
                 let pointer = Module._get_source(sourceDropdown.selectedIndex - 1);
                 sourceStr = Module.UTF8ToString(pointer);  // Convert memory address to string
             }
-            updateSource(sourceStr);
+            updateSource(currentUrl, sourceStr);
+            // Update the browser URL without causing a page reload
+            history.pushState(null, null, currentUrl.toString());
             
             setTimeout(() => {
                 const messagePtr = findFunc(searchTerm, searchType, startMonth, startDay, startYear,  endMonth, endDay, endYear, maxResults, bruteForceSearch, sourceStr, mostRecentFirst);


### PR DESCRIPTION
I noticed that when I do a search, the browser history is updated 5 times, but I only clicked on `search` once. 

I changed the JS code to update `currentUrl` in place, and then finally push consolidated param to browser history state, now it only update once per search

## manual test
before, I did 2 search
![Screenshot 2024-01-07 165815](https://github.com/richgel999/ufo_data_search/assets/22304221/4ebf824d-a9ca-4dcb-95a8-2d8eb0b1aa4c)


after, load the page, and then do a search, history is updated only once
![Screenshot 2024-01-07 165826](https://github.com/richgel999/ufo_data_search/assets/22304221/21447c71-ccc9-4560-b693-e9238795784b)

